### PR TITLE
Hotfix - Bump the ios SDK version to current (1.5.3)

### DIFF
--- a/vouched-react-native.podspec
+++ b/vouched-react-native.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React"
-  s.dependency "Vouched", "1.5.0"
+  s.dependency "Vouched", "1.5.3"
 end


### PR DESCRIPTION
Recent changes made for Xcode 14 did not make it into the current release. This hotfix addresses that, by bumping the iOS SDK version from 1.5.0 to 1.5.3