### PR TITLE
docs: add idPhoto requirements to params object

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,8 @@ Note: shouldn't be POSTed until the step is `"POSTABLE"`
 
 ##### Params `Object`
 
+Note: For id verification jobs the `idPhoto` field is a required
+
 ```javascript
 {
     "birthDate": String?,
@@ -407,6 +409,7 @@ Note: shouldn't be POSTed until the step is `"POSTABLE"`
     "firstName": String?,
     "lastName": String?,
     "phone": String?
+    "idPhoto": String? //The user's base64-encoded photo of identification document (front). Supported types are image/png, image/jpeg. required for id verification jobs
 }
 ```
 


### PR DESCRIPTION
Adds idPhoto field requirements to the readme doc. 

Closes https://github.com/orgs/vouched/projects/15/views/5?pane=issue&itemId=34396979