### PR TITLE
Use ios SDK 1.6.4

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,7 @@
     "@react-native-masked-view/masked-view": "^0.2.8",
     "@react-navigation/native": "^6.0.16",
     "@react-navigation/stack": "^6.3.7",
-    "@vouched.id/vouched-react-native": "1.2.1",
+    "@vouched.id/vouched-react-native": "1.2.2",
     "patch-package": "^6.4.7",
     "react": "18.1.0",
     "react-native": "0.70.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vouched.id/vouched-react-native",
   "title": "React Native Vouched",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Vouched React Native SDK",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/vouched-react-native.podspec
+++ b/vouched-react-native.podspec
@@ -12,12 +12,12 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/github_account/vouched-react-native"
   s.license      = "Apache-2.0"
   s.authors      = { "Vouched" => "support@vouched.id" }
-  s.platforms    = { :ios => "13.0" }
+  s.platforms    = { :ios => "12.0" }
   s.source       = { :git => "https://github.com/vouched/vouched-react-native.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,c,m,swift}"
   s.requires_arc = true
 
   s.dependency "React"
-  s.dependency "Vouched", "1.7.0-beta6"
+  s.dependency "Vouched", "1.6.4"
 end


### PR DESCRIPTION
Update RN SDK to use v1.6.4 of the iOS SDK, as it appears the 1.7.0 beta currently used has an issue that impacts App Store submission.